### PR TITLE
Added Support for Linux on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,17 @@ arch:
   - ppc64le
 
 go:
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
-  - 1.13.x
+  # - 1.6.x
+  # - 1.7.x
+  #- 1.8.x
+  #- 1.9.x
+  #- 1.10.x
+  #- 1.11.x
+  #- 1.12.x
+  #- 1.13.x
+  - 1.15.x
 
 script: 
-  - go get golang.org/x/tools/cmd/cover
+  #  - go get golang.org/x/tools/cmd/cover
   - go get github.com/smartystreets/goconvey
   - go test -v -cover -race

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: go
+arch:
+  - amd64
+  - ppc64le
+
 go:
   - 1.6.x
   - 1.7.x


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/bindata/builds/196345578
Please have a look.

**Note- Go older versions are not supported .
Please Check the older Build:
https://travis-ci.com/github/ujjwalsh/bindata/builds/191861708

Here in above: cases for Versions below 1.15.x are getting failed  (Deprecated)
Please Check and Let me Know how it can work better way.Please Let me know in case i can make any modification.

Regards,
ujjwal